### PR TITLE
Enable asymmetries

### DIFF
--- a/source/include/DataHelp/PredDistrHelp.h
+++ b/source/include/DataHelp/PredDistrHelp.h
@@ -1,0 +1,26 @@
+#ifndef LIB_PREDDISTRHELP_H
+#define LIB_PREDDISTRHELP_H 1
+
+// Includes from PrEW
+#include "Data/PredDistr.h"
+
+#include <string>
+
+namespace PrEWUtils {
+namespace DataHelp {
+  
+namespace PredDistrHelp {
+  /** Namespace for helper functions relating to the PrEW PredDistr class.
+  **/
+  
+  double get_pred_sum (
+    const PREW::Data::PredDistr & pred, 
+    const std::string & type
+  );
+  
+}
+  
+}  
+}
+
+#endif

--- a/source/include/Names/CoefNaming.h
+++ b/source/include/Names/CoefNaming.h
@@ -18,6 +18,11 @@ namespace CoefNaming {
     std::string energy_unit="GeV"
   );
   
+  std::string chi_xs_coef_name (   
+    const std::string & distr_name,
+    const std::string & chiral_config
+  );
+  
 } // Namespace CoefNaming
   
 } // Namespace Names

--- a/source/include/Names/ParNaming.h
+++ b/source/include/Names/ParNaming.h
@@ -28,6 +28,12 @@ namespace ParNaming {
     const std::string & chiral_config
   );
   
+  std::string total_chi_xs_par_name ( const std::string & distr_name );
+  std::string asymm_par_name ( 
+    const std::string & distr_name,
+    int asymm_index=0
+  );
+  
   std::string lumi_name ( int energy, std::string energy_unit="GeV" );
   
 } // Namespace ParNaming

--- a/source/include/Runners/ParallelRunner.tpp
+++ b/source/include/Runners/ParallelRunner.tpp
@@ -162,6 +162,7 @@ void ParallelRunner<SetupClass>::set_minimizers(
     PREW::CppUtils::Str::string_to_vec( minimizers_str, "->" );
   
   for (const auto & min_name: minimizers_split) {
+    spdlog::debug("ParallelRunner: Adding minimizer {}", min_name);
     m_minuit_factories.push_back(
       PREW::Fit::MinuitFactory(
         Names::MinimizerNaming::minimizer_naming_map.at(min_name),

--- a/source/include/Runners/ParallelRunner.tpp
+++ b/source/include/Runners/ParallelRunner.tpp
@@ -25,7 +25,15 @@ ParallelRunner<SetupClass>::ParallelRunner(
   m_toy_gen(PREW::ToyMeas::ToyGen(m_data_connector,setup.get_pars()))
 {
   /** Constructor extracts all relevant information from the setup.
-  TODO TODO TODO UPDATE WITH MINIMIZERS INSTRUCTIONS
+      Minimizer string describes which Minuit2 minimizers to use.
+      Multiple minimizers can be given separated by a "->".
+      Allowed minimizers are:
+        Migrad
+        Simplex
+        Combined
+        Scan
+        Fumili
+        MigradBFGS
   **/
   // Extract the parameters which should be fitted for a given energy
   for (const auto & energy: m_energies) {

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -48,6 +48,10 @@ namespace Setups {
     // Map tracking which chiral cross sections should be free for each distr
     std::map<std::string,std::vector<std::string>> m_free_xs_chi {};
     
+    // Tracking which total chiral cross sections and asymmetries are free
+    std::vector<std::string> m_free_total_xs_chi {};
+    std::map<std::string,std::vector<std::string>> m_free_asymmetries {};
+    
     public: 
       // Constructor
       RKDistrSetup();
@@ -93,6 +97,26 @@ namespace Setups {
         const std::string & chiral_config 
       );
       
+      void free_total_chiral_xsection( const std::string & distr_name );
+      void free_asymmetry( 
+        const std::string & distr_name,
+        const std::string & chiral_config_0,
+        const std::string & chiral_config_1
+      );
+      void free_asymmetry( 
+        const std::string & distr_name,
+        const std::string & chiral_config_0,
+        const std::string & chiral_config_1,
+        const std::string & chiral_config_2
+      );
+      void free_asymmetry( 
+        const std::string & distr_name,
+        const std::string & chiral_config_0,
+        const std::string & chiral_config_1,
+        const std::string & chiral_config_2,
+        const std::string & chiral_config_3
+      );
+      
       void set_WW_mu_only();
       void set_ZZ_mu_only();
       
@@ -132,6 +156,8 @@ namespace Setups {
       bool xs_chi_is_free(
         const PREW::Data::DistrInfo & info_chi
       ) const;
+      bool total_chiral_xsection_is_free(const std::string & distr_name) const;
+      bool asymm_is_free( const PREW::Data::DistrInfo & info_chi ) const;
       
       std::vector<PREW::Data::DistrInfo> get_infos_pol(
         const std::string & distr_name,
@@ -142,6 +168,12 @@ namespace Setups {
         int energy
       ) const;
       
+      void add_asymm_par( const std::string & par_name );
+      
+      void add_chi_xs_sum_coef(
+        const PREW::Data::DistrInfo & info_chi,
+        int n_bins
+      );
       void add_unity_coef(const PREW::Data::DistrInfo & info, int n_bins);
       void add_tau_removal_coef(const PREW::Data::DistrInfo & info, int n_bins);
       void add_nu_and_tau_removal_coef(
@@ -157,6 +189,12 @@ namespace Setups {
       PREW::Data::FctLink get_tau_removal_fct_link() const;
       PREW::Data::FctLink get_nu_and_tau_removal_fct_link() const;
       PREW::Data::FctLink get_chi_xs_fct_link( 
+        const PREW::Data::DistrInfo & info_chi
+      ) const;
+      PREW::Data::FctLink get_total_chi_xs_fct_link( 
+        const PREW::Data::DistrInfo & info_chi
+      ) const;
+      PREW::Data::FctLink get_asymm_fct_link( 
         const PREW::Data::DistrInfo & info_chi
       ) const;
       PREW::Data::FctLink get_lumi_fraction_fct_link(

--- a/source/src/DataHelp/PredDistrHelp.cpp
+++ b/source/src/DataHelp/PredDistrHelp.cpp
@@ -1,0 +1,33 @@
+#include <DataHelp/PredDistrHelp.h>
+
+#include "spdlog/spdlog.h"
+
+namespace PrEWUtils {
+namespace DataHelp {
+
+//------------------------------------------------------------------------------
+
+double PredDistrHelp::get_pred_sum (
+  const PREW::Data::PredDistr & pred, 
+  const std::string & type
+) {
+  /** Return the sum of the predicted distribution bins.
+      Can be "signal", "background" or "S+B".
+  **/
+  double sum = 0;
+  
+  if ( ( type == "signal" ) || ( type == "S+B" ) ) {
+    for (const auto & val: pred.m_sig_distr) { sum += val; }
+  } else if ( ( type == "background" ) || ( type == "S+B" ) ) {
+    for (const auto & val: pred.m_bkg_distr) { sum += val; }
+  } else {
+    spdlog::warn("PredDistrHelp: Unknown sum type: {}", type);
+  }
+  
+  return sum;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/src/Names/CoefNaming.cpp
+++ b/source/src/Names/CoefNaming.cpp
@@ -17,5 +17,17 @@ std::string CoefNaming::lumi_fraction_name (
 
 //------------------------------------------------------------------------------
 
+std::string CoefNaming::chi_xs_coef_name ( 
+  const std::string & distr_name,
+  const std::string & chiral_config
+) {
+  /** Naming convention for the coefficient that stores the total chiral cross
+      section of a distribution.
+  **/
+  return "ChiXS_" + distr_name + "_" + chiral_config;
+}
+
+//------------------------------------------------------------------------------
+
 } // Namespace Names
 } // Namespace PrEWUtils

--- a/source/src/Names/ParNaming.cpp
+++ b/source/src/Names/ParNaming.cpp
@@ -28,6 +28,39 @@ std::string ParNaming::chi_xs_par_name(
   
 //------------------------------------------------------------------------------
 
+std::string ParNaming::total_chi_xs_par_name(const std::string & distr_name) {
+  /** Convention for naming the parameter corresponding to the scaling of the
+      sum of the chiral cross sections for a given distribution.
+  **/
+  return "ScaleTotChiXS_" + distr_name;
+}
+
+std::string ParNaming::asymm_par_name ( 
+  const std::string & distr_name,
+  int asymm_index 
+) {
+  /** Convention for naming the parameters corresponding to asymmetries for a 
+      given distribution.
+      Contains an index in case more than one symmetry is allowed.
+  **/
+  std::string par_name = "DeltaA";
+  
+  // Figure out which asymmetry parameter is meant
+  switch(asymm_index) {
+    case 0 : break;
+    case 1 : par_name += "_I";   break;
+    case 2 : par_name += "_II";  break;
+    case 3 : par_name += "_III"; break;
+    default: 
+      spdlog::error("ParNaming: Unknown asymmetry index {}!", asymm_index);
+      return "";
+  }
+  par_name += "_" + distr_name;
+  return par_name;
+}
+
+//------------------------------------------------------------------------------
+
 std::string ParNaming::lumi_name ( int energy, std::string energy_unit ) {
   /** Convention for naming the luminosity parameter.
   **/

--- a/source/src/Setups/RKDistrSetup.cpp
+++ b/source/src/Setups/RKDistrSetup.cpp
@@ -230,7 +230,22 @@ void RKDistrSetup::complete_setup() {
     for (const auto & distr_name : m_used_distr_names) {    
       this->complete_distr_setup( distr_name, energy );
     } 
-  } 
+  }
+  
+  // For debugging:
+  spdlog::debug("RKDistrSetup: Printing results of completed setup");
+  spdlog::debug("Using distributions:");
+  for ( const auto & used_distr: m_used_distrs ) {
+    const auto & info = used_distr.m_info;
+    spdlog::debug("{} @ {} & {}", info.m_distr_name, info.m_energy, info.m_pol_config);
+    spdlog::debug(" -> First signal value: {}", used_distr.m_sig_distr.at(0));
+  }
+  spdlog::debug("Using coefficients:");
+  for ( const auto & used_coef: m_used_coefs ) {
+    const auto & info = used_coef.m_info;
+    spdlog::debug("{} for {} @ {} & {}", used_coef.m_coef_name, info.m_distr_name, info.m_energy, info.m_pol_config);
+    spdlog::debug(" -> First coef value: {}", used_coef.m_coefficients.at(0));
+  }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Add helper function for PredDistr that calculates the sum of the predicted distribution.
- Add naming convention for the coefficient describing the total chiral cross section.
- Add parameter naming convention for total chiral cross section scaling.
- Add parameter naming convention for chiral asymmetries.
- Fix the documentation in ParallelRunner class.
- Add debug statements to ParallelRunner and RKDistrSetup.
- In RKDistrSetup enable setting up parameters for chiral asymmetries and total chiral cross sections.