### PR TITLE
Adapt load_env macro to different paths at home and on NAF

### DIFF
--- a/macros/load_env.sh
+++ b/macros/load_env.sh
@@ -1,3 +1,22 @@
 #!/bin/bash
 
-source ../../PrEW/macros/load_env.sh
+# Script tries to use the setup used by PrEW 
+# => Tries to find it on my NAF, else see if a local version exists
+
+PrEW_NAF_dir="/afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/PrEW"
+PrEW_local_dir="../../PrEW"
+
+PrEW_dir=""
+
+if [ -d "${PrEW_NAF_dir}" ] ; then
+  echo "Found PrEW on NAF."
+  PrEW_dir="${PrEW_NAF_dir}"
+elif [ -d "${PrEW_local_dir}" ] ; then
+  echo "Found PrEW on local computer."
+  PrEW_dir="${PrEW_local_dir}"
+else 
+  echo "ERROR: Did not find PrEW!"
+  exit
+fi
+
+source ${PrEW_dir}/macros/load_env.sh


### PR DESCRIPTION
- Adapt the load_env.sh macro to the different paths of PrEW at home and on NAF.