### PR TITLE
Add bin selection

### DIFF
--- a/source/include/DataHelp/BinSelector.h
+++ b/source/include/DataHelp/BinSelector.h
@@ -1,0 +1,35 @@
+#ifndef LIB_BINSELECTOR_H
+#define LIB_BINSELECTOR_H 1
+
+// Includes from PrEW
+#include "Fit/FitContainer.h"
+#include "Fit/FitPar.h"
+
+// TODO TODO TODO This should be part of PrEW
+namespace PrEWUtils {
+namespace DataHelp {
+  
+  class BinSelector {
+    /** Class designed to execute a cutoff on which bins should be considered
+        in a minimization.
+        The cutoff checks the bin prediction for a given set of parameter values
+        and if it is below a given cutoff the bin is not considered in the 
+        minimization.
+    **/
+
+    double m_cut_val {}; 
+    PREW::Fit::ParVec m_pars_for_cut {};
+
+    public:
+      // Constructors
+      BinSelector() {};
+      BinSelector(double cut_val, PREW::Fit::ParVec pars_for_cut);
+      
+      // Core functionality
+      void remove_bins(PREW::Fit::FitContainer * container) const;
+  };
+  
+} // Namespace DataHelp
+} // Namespace PrEWUtils
+
+#endif

--- a/source/include/Runners/ParallelRunner.h
+++ b/source/include/Runners/ParallelRunner.h
@@ -1,6 +1,7 @@
 #ifndef LIB_PARALLELRUNNER_H
 #define LIB_PARALLELRUNNER_H 1
 
+#include <DataHelp/BinSelector.h>
 #include <Parallel/ThreadPool.h>
 
 // Includes from PREW
@@ -21,12 +22,15 @@ namespace Runners {
     /** Class to run a given toy setup in multiple threads in parallel.
     **/
     
-    // DataConnector, ToyGen
     std::vector<int> m_energies;
     std::map<int, PREW::Fit::ParVec> m_pars; // Parameters used at each energy
     PREW::Connect::DataConnector m_data_connector;
     PREW::ToyMeas::ToyGen m_toy_gen;
     std::vector<PREW::Fit::MinuitFactory> m_minuit_factories;
+    
+    // Extra options
+    bool m_use_selector {false};
+    DataHelp::BinSelector m_bin_selector {};
     
     public:
       // Constructors
@@ -34,6 +38,9 @@ namespace Runners {
         const SetupClass & setup,
         const std::string & minimizers
       );
+      
+      // Set extra options
+      void set_bin_selector(DataHelp::BinSelector bin_selector);
       
       // Running toy fits
       PREW::Fit::ResultVec run_toy_fits(

--- a/source/include/Runners/ParallelRunner.tpp
+++ b/source/include/Runners/ParallelRunner.tpp
@@ -46,6 +46,18 @@ ParallelRunner<SetupClass>::ParallelRunner(
 //------------------------------------------------------------------------------
 
 template <class SetupClass>
+void ParallelRunner<SetupClass>::set_bin_selector(
+  DataHelp::BinSelector bin_selector
+) {
+  /** Set a bin selector that excludes bins from the minimization process.
+  **/
+  m_bin_selector = bin_selector;
+  m_use_selector = true;
+}
+
+//------------------------------------------------------------------------------
+
+template <class SetupClass>
 PREW::Fit::ResultVec ParallelRunner<SetupClass>::run_toy_fits(
   int energy,
   int n_toys, 
@@ -195,6 +207,9 @@ ParallelRunner<SetupClass>::single_fit_task(int energy) const {
     m_pars.at(energy),
     &container
   );
+  
+  // If requested remove bins according to selector
+  if ( m_use_selector ) { m_bin_selector.remove_bins(&container); }
   
   // Minimize with all given minimizers, save only the results of the last one
   PREW::Fit::FitResult final_result {};

--- a/source/src/DataHelp/BinSelector.cpp
+++ b/source/src/DataHelp/BinSelector.cpp
@@ -1,0 +1,68 @@
+#include <DataHelp/BinSelector.h>
+
+#include "spdlog/spdlog.h"
+
+namespace PrEWUtils {
+namespace DataHelp {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+BinSelector::BinSelector( double cut_val, PREW::Fit::ParVec pars_for_cut ) :
+  m_cut_val(cut_val), m_pars_for_cut(pars_for_cut) {}
+
+//------------------------------------------------------------------------------
+
+void BinSelector::remove_bins( PREW::Fit::FitContainer * container ) const {
+  /** Function manipulates FitContainer, it removes all bins whose prediction
+      is below the cutoff value for the set of parameters chosen for the cutoff.
+      Preserves the parameters of the fitcontainer.
+  **/
+  int n_pars = container->m_fit_pars.size();
+  
+  // Preserve the initial parameters
+  std::vector<double> par_vals_ini (n_pars);
+  for ( int p=0; p<n_pars; p++ ) {
+    par_vals_ini[p] = container->m_fit_pars[p].m_val_mod;
+  }
+  
+  // Set the parameters to the set given at construction
+  for ( const auto & par : m_pars_for_cut ) {
+    // Look for this parameter and replace the value when found.
+    // (Go old fashioned in this loop to be sure you know what's happening)
+    for ( int p=0; p<n_pars; p++ ) {
+      if ( container->m_fit_pars[p].get_name() == par.get_name() ) {
+        container->m_fit_pars[p].m_val_mod = par.m_val_mod;
+        break;
+      }
+    }
+  }
+  
+  // Perform the cutoff:
+  // First check which bins need to be cut, then cut them out of bin vector
+  int n_bins = container->m_fit_bins.size();
+  std::vector<int> ind_to_remove {}; // Vector for indices to remove
+  for ( int b=0; b<n_bins; b++ ) {
+    if ( container->m_fit_bins[b].get_val_prd() < m_cut_val ) {
+      // Bin should be removed, save its index
+      ind_to_remove.push_back(b);
+    }
+  }
+  
+  // Cut them from back to front to avoid index shift before cut
+  for ( int i=ind_to_remove.size()-1; i>=0; i-- ) {
+    int b = ind_to_remove[i];
+    // Deleting the b-th element
+    container->m_fit_bins.erase( container->m_fit_bins.begin() + b ); 
+  }
+  
+  // Now reset the parameter values to how they were before bin erasure
+  for ( int p=0; p<n_pars; p++ ) {
+    container->m_fit_pars[p].m_val_mod = par_vals_ini[p];
+  }
+}
+
+//------------------------------------------------------------------------------
+
+} // Namespace DataHelp
+} // Namespace PrEWUtils


### PR DESCRIPTION
- Add BinSelector class that can remove bins from a FitContainer if their prediction for a given set of parameters falls below a cutoff.
- Allow setting a BinSelector to cut away low-entry bins from a minimization in the ParallelRunner class.

