### PR TITLE
Add parameter fixing

### DIFF
--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -90,6 +90,9 @@ namespace Setups {
         double constr_unc
       );
       
+      void fix_lumi(int energy);
+      void fix_pol(const std::string & name, int energy);
+      
       void activate_cTGCs();
       
       void free_chiral_xsection( 

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -138,6 +138,14 @@ namespace Setups {
       void read_input_file(const std::string & file_path, int energy);
       void read_input_files();
       
+      // Internal helpers
+      PREW::Fit::FitPar & find_par_in_vec(
+        const std::string & par_name,
+        PREW::Fit::ParVec & vec
+      );
+      PREW::Fit::FitPar & find_par(const std::string & name);
+      PREW::Fit::FitPar & find_par(const std::string & name, int energy);
+      
       // Linking related
       void complete_distr_setup(const std::string & distr_name, int energy);
       void complete_chi_setup(

--- a/source/src/Setups/RKDistrSetup.cpp
+++ b/source/src/Setups/RKDistrSetup.cpp
@@ -143,6 +143,24 @@ void RKDistrSetup::add_pol_constr(
   (this->find_par(name,energy)).set_constrgauss( constr_val, constr_unc );
 }
 
+//------------------------------------------------------------------------------
+
+void RKDistrSetup::fix_lumi(int energy) {
+  /** Fix the luminosity parameter at the given energy to its current value.
+      Will not be varied by fit.
+  **/
+  std::string name = Names::ParNaming::lumi_name(energy);
+  (this->find_par(name,energy)).fix();
+}
+
+//------------------------------------------------------------------------------
+
+void RKDistrSetup::fix_pol(const std::string & name, int energy) {
+  /** Fix the polarisation parameter at the given energy to its current value.
+      Will not be varied by fit.
+  **/
+  (this->find_par(name,energy)).fix();
+}
 
 //------------------------------------------------------------------------------
 

--- a/source/src/Setups/RKDistrSetup.cpp
+++ b/source/src/Setups/RKDistrSetup.cpp
@@ -127,15 +127,7 @@ void RKDistrSetup::add_lumi_constr(
       energy.
   **/
   std::string name = Names::ParNaming::lumi_name(energy);
-  auto name_cond = 
-    [name](const PREW::Fit::FitPar &par){return par.get_name()==name;};
-  auto lumi_it = 
-    find_if( 
-      m_separate_pars.at(energy).begin(), 
-      m_separate_pars.at(energy).end(), 
-      name_cond
-    );
-  lumi_it->set_constrgauss( constr_val, constr_unc );
+  (this->find_par(name,energy)).set_constrgauss( constr_val, constr_unc );
 }
 
 //------------------------------------------------------------------------------
@@ -148,15 +140,7 @@ void RKDistrSetup::add_pol_constr(
 ) {
   /** Add a gaussian constraint on the given single beam polarisation.
   **/
-  auto name_cond = 
-    [name](const PREW::Fit::FitPar &par){return par.get_name()==name;};
-  auto pol_it = 
-    find_if( 
-      m_separate_pars.at(energy).begin(), 
-      m_separate_pars.at(energy).end(), 
-      name_cond
-    );
-  pol_it->set_constrgauss( constr_val, constr_unc );
+  (this->find_par(name,energy)).set_constrgauss( constr_val, constr_unc );
 }
 
 
@@ -521,6 +505,38 @@ void RKDistrSetup::read_input_files() {
       this->read_input_file(file_path, energy);
     }
   }
+}
+
+//------------------------------------------------------------------------------
+
+PREW::Fit::FitPar & RKDistrSetup::find_par_in_vec(
+  const std::string & par_name,
+  PREW::Fit::ParVec & vec
+) {
+  /** Find the fit parameter of given name in the given vector and return a 
+      (non-const) reference to it.
+  **/
+  auto name_cond =
+    [par_name](const PREW::Fit::FitPar &par){return par.get_name()==par_name;};
+  auto par_it = std::find_if(vec.begin(), vec.end(), name_cond);
+  if ( par_it == vec.end() ) {
+    throw std::invalid_argument( ("Couldn't find parameter " + par_name + " in vector!").c_str() );
+  }
+  return *par_it;
+}
+
+PREW::Fit::FitPar & RKDistrSetup::find_par(const std::string & name) {
+  /** Find the parameter of given name in the common parameters and return a 
+      (non-const) reference to it.
+  **/
+  return this->find_par_in_vec(name, m_common_pars);
+}
+
+PREW::Fit::FitPar & RKDistrSetup::find_par(const std::string & name, int energy) {
+  /** Find the parameter of given name in the energy-specific parameters and 
+      return a (non-const) reference to it.
+  **/
+  return this->find_par_in_vec(name, m_separate_pars.at(energy));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Add internal helper functions to RKDistrSetup class that it can use to find parameters in its parameter vectors.
- Adapt RKDistrSetup function code to use internal helper functions.
- Add parameter fixing functions for luminosity and polarisations to RKDistrSetup.

