### PR TITLE
Adapt asymmetries

### DIFF
--- a/source/include/DataHelp/PredDistrHelp.h
+++ b/source/include/DataHelp/PredDistrHelp.h
@@ -2,6 +2,7 @@
 #define LIB_PREDDISTRHELP_H 1
 
 // Includes from PrEW
+#include <Data/CoefDistr.h>
 #include "Data/PredDistr.h"
 
 #include <string>
@@ -17,6 +18,9 @@ namespace PredDistrHelp {
     const PrEW::Data::PredDistr & pred, 
     const std::string & type
   );
+  
+  std::vector<double> pred_to_coef(const PrEW::Data::PredDistr &pred,
+                                   const std::string &type = "signal");
   
 }
   

--- a/source/include/Names/CoefNaming.h
+++ b/source/include/Names/CoefNaming.h
@@ -18,10 +18,7 @@ namespace CoefNaming {
     std::string energy_unit="GeV"
   );
   
-  std::string chi_xs_coef_name (   
-    const std::string & distr_name,
-    const std::string & chiral_config
-  );
+  std::string chi_xs_coef_name ( const PrEW::Data::DistrInfo & info_chi );
   
 } // Namespace CoefNaming
   

--- a/source/include/Names/CoefNaming.h
+++ b/source/include/Names/CoefNaming.h
@@ -19,7 +19,10 @@ namespace CoefNaming {
   );
   
   std::string chi_xs_coef_name ( const PrEW::Data::DistrInfo & info_chi );
+  std::string chi_distr_coef_name ( const PrEW::Data::DistrInfo & info_chi, 
+                                    const std::string type="signal" );
   
+  std::string costheta_index_coef_name();
 } // Namespace CoefNaming
   
 } // Namespace Names

--- a/source/include/Names/FctNaming.h
+++ b/source/include/Names/FctNaming.h
@@ -1,0 +1,23 @@
+#ifndef LIB_FCTNAMING_H
+#define LIB_FCTNAMING_H 1
+
+// Includes from PrEW
+#include "Data/DistrInfo.h"
+
+#include <string>
+
+namespace PrEWUtils {
+namespace Names {
+
+namespace FctNaming {
+/** Namespace for some conventions of how functions are named in PrEW.
+ **/
+
+std::string chiral_asymm_name(int config_index, int n_configs);
+
+} // Namespace FctNaming
+
+} // Namespace Names
+} // Namespace PrEWUtils
+
+#endif

--- a/source/include/Names/ParNaming.h
+++ b/source/include/Names/ParNaming.h
@@ -34,6 +34,8 @@ namespace ParNaming {
     int asymm_index=0
   );
   
+  std::string Af_par_name ( const std::string & distr_name );
+  
   std::string lumi_name ( int energy, std::string energy_unit="GeV" );
   
 } // Namespace ParNaming

--- a/source/include/SetupHelp/AfInfo.h
+++ b/source/include/SetupHelp/AfInfo.h
@@ -1,0 +1,55 @@
+#ifndef LIB_AFINFO_H
+#define LIB_AFINFO_H 1
+
+// Includes from PrEW
+#include <Data/FctLink.h>
+#include <Fit/FitPar.h>
+#include <GlobalVar/Chiral.h>
+
+// Standard library
+#include <string>
+#include <vector>
+
+namespace PrEWUtils {
+namespace SetupHelp {
+
+class AfInfo {
+  /** Helper class that desribes the information connected to an Af parameter
+      for a 2-fermion distribution.
+      Af = [ (c_L^f)^2 - (c_R^f)^2 ] / [ (c_L^f)^2 + (c_R^f)^2 ]
+  **/
+
+  std::string m_distr_name{};
+  std::string m_Af_name{};
+  std::string m_LR_config{};
+  std::string m_RL_config{};
+
+public:
+  // Constructors
+  AfInfo(const std::string &distr_name,
+         const std::string &Af_name = "default",
+         const std::string &LR_config = PrEW::GlobalVar::Chiral::eLpR,
+         const std::string &RL_config = PrEW::GlobalVar::Chiral::eRpL);
+
+  // Access functions
+  const std::string &get_distr_name() const;
+  const std::string &get_Af_name() const;
+  const std::string &get_LR_config() const;
+  const std::string &get_RL_config() const;
+
+  // Functions needed for setting up PrEW fit
+  PrEW::Fit::FitPar get_par(double initial_val = 0,
+                            double initial_unc = 0.0001) const;
+  PrEW::Data::FctLink get_fct_link(int energy,
+                                   const std::string &chiral_config) const;
+
+protected:
+  // Internal functions
+  // int chiral_config_index(const std::string &chiral_config) const;
+  // std::vector<std::string> xs_coef_names(int energy) const;
+};
+
+} // namespace SetupHelp
+} // namespace PrEWUtils
+
+#endif

--- a/source/include/SetupHelp/ChiAsymmInfo.h
+++ b/source/include/SetupHelp/ChiAsymmInfo.h
@@ -1,0 +1,52 @@
+#ifndef LIB_CHIASYMMINFO_H
+#define LIB_CHIASYMMINFO_H 1
+
+// Includes from PrEW
+#include <Data/FctLink.h>
+#include <Fit/FitPar.h>
+
+// Standard library
+#include <string>
+#include <vector>
+
+namespace PrEWUtils {
+namespace SetupHelp {
+
+class ChiAsymmInfo {
+  /** Helper struct that desribes the information connected to a  asymmetry
+      for a distribution.
+  **/
+
+  std::string m_distr_name{};
+  std::vector<std::string> m_chiral_configs{};
+  std::vector<std::string> m_par_names{};
+  int m_n_asymms{};
+
+public:
+  // Constructors
+  ChiAsymmInfo(const std::string &distr_name,
+               const std::vector<std::string> &chiral_configs,
+               const std::vector<std::string> &par_names = {});
+
+  // Access functions
+  const std::string &get_distr_name() const;
+  const std::vector<std::string> &get_chiral_configs() const;
+  const std::vector<std::string> &get_par_names() const;
+  int get_n_asymms() const;
+
+  // Functions needed for setting up PrEW fit
+  PrEW::Fit::ParVec get_pars(double initial_val = 0,
+                             double initial_unc = 0.0001) const;
+  PrEW::Data::FctLink get_fct_link(int energy,
+                                   const std::string &chiral_config) const;
+
+protected:
+  // Internal functions
+  int chiral_config_index(const std::string &chiral_config) const;
+  std::vector<std::string> xs_coef_names(int energy) const;
+};
+
+} // namespace SetupHelp
+} // namespace PrEWUtils
+
+#endif

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -1,6 +1,7 @@
 #ifndef LIB_RKDISTRSETUP_H
 #define LIB_RKDISTRSETUP_H 1
 
+#include <SetupHelp/AfInfo.h>
 #include <SetupHelp/ChiAsymmInfo.h>
 
 // Includes from PrEW
@@ -47,12 +48,11 @@ namespace Setups {
     bool m_WW_mu_only {};
     bool m_ZZ_mu_only {};
     
-    // Map tracking which chiral cross sections should be free for each distr
+    // Internal tracking for which parameters should be free
     std::map<std::string,std::vector<std::string>> m_free_xs_chi {};
-    
-    // Tracking which total chiral cross sections and asymmetries are free
     std::vector<std::string> m_free_total_xs_chi {};
     std::vector<SetupHelp::ChiAsymmInfo> m_free_chi_asymms {};
+    std::vector<SetupHelp::AfInfo> m_free_Af {};
     
     public: 
       // Constructor
@@ -120,7 +120,10 @@ namespace Setups {
         const std::string & asymI_name = "default",
         const std::string & asymII_name = "default"
       );
-      
+      void
+      free_2f_final_state_asymmetry(const std::string &distr_name,
+                                    const std::string &asym_name = "default");
+
       void set_WW_mu_only();
       void set_ZZ_mu_only();
       
@@ -159,6 +162,7 @@ namespace Setups {
       // Linking related
       void complete_distr_setup(const std::string & distr_name, int energy);
       void complete_chi_asymm_setup();
+      void complete_Af_setup();
       
       PrEW::Data::PredDistrVec determine_distrs(
         const std::string & distr_name, int energy
@@ -191,11 +195,11 @@ namespace Setups {
         int energy
       ) const;
       
-      void add_chi_xs_sum_coefs(
-        const std::string & distr_name,
-        int energy,
-        const std::vector<std::string> & chiral_configs
-      );
+      void add_chi_distr_coefs(const PrEW::Data::DistrInfo & info, 
+                               const std::vector<std::string> & chiral_configs, 
+                               const std::string &type);
+      void add_costheta_index_coef(const PrEW::Data::DistrInfo & info, 
+                                   int costheta_index);
       void add_unity_coef(const PrEW::Data::DistrInfo & info, int n_bins);
       void add_tau_removal_coef(const PrEW::Data::DistrInfo & info, int n_bins);
       void add_nu_and_tau_removal_coef(

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -150,6 +150,7 @@ namespace Setups {
       PrEW::Fit::FitPar & find_par(const std::string & name);
       PrEW::Fit::FitPar & find_par(const std::string & name, int energy);
       PrEW::Data::PredLink & find_pred_link(const PrEW::Data::DistrInfo & info);
+      PrEW::Data::PredDistr &find_pred_distr(const PrEW::Data::DistrInfo & info);
       
       void add_par(const PrEW::Fit::FitPar &par);
       void add_par(const PrEW::Fit::FitPar &par, int energy);

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -186,8 +186,6 @@ namespace Setups {
         int energy
       ) const;
       
-      void add_asymm_par( const std::string & par_name );
-      
       void add_chi_xs_sum_coefs(
         const std::string & distr_name,
         int energy,

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -1,6 +1,8 @@
 #ifndef LIB_RKDISTRSETUP_H
 #define LIB_RKDISTRSETUP_H 1
 
+#include <SetupHelp/ChiAsymmInfo.h>
+
 // Includes from PrEW
 #include "Connect/DataConnector.h"
 #include "Data/CoefDistr.h"
@@ -50,7 +52,7 @@ namespace Setups {
     
     // Tracking which total chiral cross sections and asymmetries are free
     std::vector<std::string> m_free_total_xs_chi {};
-    std::map<std::string,std::vector<std::string>> m_free_asymmetries {};
+    std::vector<SetupHelp::ChiAsymmInfo> m_free_chi_asymms {};
     
     public: 
       // Constructor
@@ -104,23 +106,19 @@ namespace Setups {
       );
       
       void free_total_chiral_xsection( const std::string & distr_name );
-      void free_asymmetry( 
-        const std::string & distr_name,
-        const std::string & chiral_config_0,
-        const std::string & chiral_config_1
-      );
-      void free_asymmetry( 
+      void free_asymmetry_2xs( 
         const std::string & distr_name,
         const std::string & chiral_config_0,
         const std::string & chiral_config_1,
-        const std::string & chiral_config_2
+        const std::string & asym_name = "default"
       );
-      void free_asymmetry( 
+      void free_asymmetry_3xs( 
         const std::string & distr_name,
         const std::string & chiral_config_0,
         const std::string & chiral_config_1,
         const std::string & chiral_config_2,
-        const std::string & chiral_config_3
+        const std::string & asymI_name = "default",
+        const std::string & asymII_name = "default"
       );
       
       void set_WW_mu_only();
@@ -151,9 +149,11 @@ namespace Setups {
       );
       PrEW::Fit::FitPar & find_par(const std::string & name);
       PrEW::Fit::FitPar & find_par(const std::string & name, int energy);
+      PrEW::Data::PredLink & find_pred_link(const PrEW::Data::DistrInfo & info);
       
       // Linking related
       void complete_distr_setup(const std::string & distr_name, int energy);
+      void complete_chi_asymm_setup();
       
       PrEW::Data::PredDistrVec determine_distrs(
         const std::string & distr_name, int energy
@@ -176,7 +176,6 @@ namespace Setups {
         const PrEW::Data::DistrInfo & info_chi
       ) const;
       bool total_chiral_xsection_is_free(const std::string & distr_name) const;
-      bool asymm_is_free( const PrEW::Data::DistrInfo & info_chi ) const;
       
       std::vector<PrEW::Data::DistrInfo> get_infos_pol(
         const std::string & distr_name,
@@ -189,9 +188,10 @@ namespace Setups {
       
       void add_asymm_par( const std::string & par_name );
       
-      void add_chi_xs_sum_coef(
-        const PrEW::Data::DistrInfo & info_chi,
-        int n_bins
+      void add_chi_xs_sum_coefs(
+        const std::string & distr_name,
+        int energy,
+        const std::vector<std::string> & chiral_configs
       );
       void add_unity_coef(const PrEW::Data::DistrInfo & info, int n_bins);
       void add_tau_removal_coef(const PrEW::Data::DistrInfo & info, int n_bins);
@@ -211,9 +211,6 @@ namespace Setups {
         const PrEW::Data::DistrInfo & info_chi
       ) const;
       PrEW::Data::FctLink get_total_chi_xs_fct_link( 
-        const PrEW::Data::DistrInfo & info_chi
-      ) const;
-      PrEW::Data::FctLink get_asymm_fct_link( 
         const PrEW::Data::DistrInfo & info_chi
       ) const;
       PrEW::Data::FctLink get_lumi_fraction_fct_link(

--- a/source/include/Setups/RKDistrSetup.h
+++ b/source/include/Setups/RKDistrSetup.h
@@ -151,6 +151,10 @@ namespace Setups {
       PrEW::Fit::FitPar & find_par(const std::string & name, int energy);
       PrEW::Data::PredLink & find_pred_link(const PrEW::Data::DistrInfo & info);
       
+      void add_par(const PrEW::Fit::FitPar &par);
+      void add_par(const PrEW::Fit::FitPar &par, int energy);
+      void add_coef(const PrEW::Data::CoefDistr &coef);
+      
       // Linking related
       void complete_distr_setup(const std::string & distr_name, int energy);
       void complete_chi_asymm_setup();

--- a/source/src/DataHelp/PredDistrHelp.cpp
+++ b/source/src/DataHelp/PredDistrHelp.cpp
@@ -1,4 +1,8 @@
 #include <DataHelp/PredDistrHelp.h>
+#include <Names/CoefNaming.h>
+
+// Includes from PrEW
+#include <Data/CoefDistr.h>
 
 #include "spdlog/spdlog.h"
 
@@ -25,6 +29,36 @@ double PredDistrHelp::get_pred_sum (
   }
   
   return sum;
+}
+
+//------------------------------------------------------------------------------
+
+std::vector<double>
+PredDistrHelp::pred_to_coef(const PrEW::Data::PredDistr &pred,
+                            const std::string &type) {
+  /** Turn the given part of the distribution (type=signal/background/total) 
+      into a differential coefficient.
+   **/
+  if ((type != "signal") && (type != "background") && (type != "total")) {
+    throw std::invalid_argument(("Unknown type of distr coef requested: "
+                                + type).c_str());
+  }
+   
+  int n_bins = pred.m_bin_centers.size();
+   
+  std::vector<double> coefs (n_bins, 0);
+  
+  // Get the coefficient depending on the requested type
+  for (int b=0; b<n_bins; b++) {
+    if ( (type == "signal") || (type == "total") ) {
+      coefs[b] += pred.m_sig_distr[b];
+    }
+    if ( (type == "background") || (type == "total") ) {
+      coefs[b] += pred.m_bkg_distr[b];
+    }
+  }
+  
+  return coefs;
 }
 
 //------------------------------------------------------------------------------

--- a/source/src/Names/CoefNaming.cpp
+++ b/source/src/Names/CoefNaming.cpp
@@ -1,5 +1,7 @@
 #include <Names/CoefNaming.h>
 
+#include <string>
+
 namespace PrEWUtils {
 namespace Names {
 
@@ -18,13 +20,13 @@ std::string CoefNaming::lumi_fraction_name (
 //------------------------------------------------------------------------------
 
 std::string CoefNaming::chi_xs_coef_name ( 
-  const std::string & distr_name,
-  const std::string & chiral_config
+  const PrEW::Data::DistrInfo & info_chi
 ) {
   /** Naming convention for the coefficient that stores the total chiral cross
       section of a distribution.
   **/
-  return "ChiXS_" + distr_name + "_" + chiral_config;
+  return "ChiXS_" + info_chi.m_distr_name + "_" + info_chi.m_pol_config +
+         "_" + std::to_string(info_chi.m_energy);
 }
 
 //------------------------------------------------------------------------------

--- a/source/src/Names/CoefNaming.cpp
+++ b/source/src/Names/CoefNaming.cpp
@@ -31,5 +31,26 @@ std::string CoefNaming::chi_xs_coef_name (
 
 //------------------------------------------------------------------------------
 
+std::string 
+CoefNaming::chi_distr_coef_name ( const PrEW::Data::DistrInfo & info_chi, 
+                                  const std::string type ) {
+  /** Naming convention for the coefficient that stores the differential 
+      cross section as coefficients.
+  **/
+  return "ChiDistr_" + info_chi.m_distr_name + "_" + info_chi.m_pol_config +
+         "_" + std::to_string(info_chi.m_energy) + "_" + type;
+}
+
+//------------------------------------------------------------------------------
+
+std::string CoefNaming::costheta_index_coef_name(){
+  /** Name for the coefficient that describes the index of the cos(Theta) 
+      observable in the observables vector.
+  **/
+  return "CosThetaIndex";
+}
+
+//------------------------------------------------------------------------------
+
 } // Namespace Names
 } // Namespace PrEWUtils

--- a/source/src/Names/FctNaming.cpp
+++ b/source/src/Names/FctNaming.cpp
@@ -1,0 +1,20 @@
+#include <Names/FctNaming.h>
+
+namespace PrEWUtils {
+namespace Names {
+
+//------------------------------------------------------------------------------
+
+std::string FctNaming::chiral_asymm_name(int config_index, int n_configs) {
+  /** Convention for how a function for a chiral asymmetry is named.
+      The name depends on the index of the specific chiral configuration and the
+      total number of chiral configurations in this asymmetry.
+  **/
+  return "AsymmFactor" + std::to_string(config_index) + "_" +
+         std::to_string(n_configs) + "allowed";
+}
+
+//------------------------------------------------------------------------------
+
+} // Namespace Names
+} // Namespace PrEWUtils

--- a/source/src/Names/ParNaming.cpp
+++ b/source/src/Names/ParNaming.cpp
@@ -61,6 +61,15 @@ std::string ParNaming::asymm_par_name (
 
 //------------------------------------------------------------------------------
 
+std::string ParNaming::Af_par_name ( const std::string & distr_name ) {
+  /** Convention on how to name the (Delta-)Af parameter for a 2-fermion
+      distribution.
+  **/
+  return "Af_" + distr_name;
+}
+
+//------------------------------------------------------------------------------
+
 std::string ParNaming::lumi_name ( int energy, std::string energy_unit ) {
   /** Convention for naming the luminosity parameter.
   **/

--- a/source/src/SetupHelp/AfInfo.cpp
+++ b/source/src/SetupHelp/AfInfo.cpp
@@ -1,0 +1,77 @@
+#include <Names/CoefNaming.h>
+#include <Names/FctNaming.h>
+#include <Names/ParNaming.h>
+#include <SetupHelp/AfInfo.h>
+
+#include <string>
+
+#include "spdlog/spdlog.h"
+
+namespace PrEWUtils {
+namespace SetupHelp {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+AfInfo::AfInfo(const std::string &distr_name, const std::string &Af_name,
+               const std::string &LR_config, const std::string &RL_config)
+    : m_distr_name(distr_name), m_Af_name(Af_name), m_LR_config(LR_config),
+      m_RL_config(RL_config) {
+  /** Constructor copies given parameters.
+      If the asymmetry parameter name is "default", then the PrEWUtils
+   convention is used.
+   **/
+
+  if (m_Af_name == "default") {
+    m_Af_name = Names::ParNaming::Af_par_name(m_distr_name);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Access functions
+
+const std::string &AfInfo::get_distr_name() const { return m_distr_name; }
+const std::string &AfInfo::get_Af_name() const { return m_Af_name; }
+const std::string &AfInfo::get_LR_config() const { return m_LR_config; }
+const std::string &AfInfo::get_RL_config() const { return m_RL_config; }
+
+//------------------------------------------------------------------------------
+// Functions to use asymmetry in PrEW
+
+PrEW::Fit::FitPar AfInfo::get_par(double initial_val,
+                                  double initial_unc) const {
+  /** Get the PrEW FitPar for this Af parameter.
+   **/
+  return PrEW::Fit::FitPar(m_Af_name, initial_val, initial_unc);
+}
+
+PrEW::Data::FctLink
+AfInfo::get_fct_link(int energy, const std::string &chiral_config) const {
+  /** Get PrEW function link for a single chiral configuration.
+      Chiral config must use PrEW conventions or naming chiral configs.
+      These function links are used by PrEW as instructions for how to set
+   up the bin predictions.
+   **/
+  PrEW::Data::DistrInfo info{m_distr_name, chiral_config, energy};
+
+  PrEW::Data::FctLink fct_link{};
+  fct_link.m_pars = {m_Af_name};
+  fct_link.m_coefs = {Names::CoefNaming::chi_xs_coef_name(info),
+                      Names::CoefNaming::chi_distr_coef_name(info, "signal"),
+                      Names::CoefNaming::costheta_index_coef_name()};
+
+  if (chiral_config == PrEW::GlobalVar::Chiral::eLpR) {
+    fct_link.m_fct_name = "AsymmFactorLR_Af_2f";
+  } else if (chiral_config == PrEW::GlobalVar::Chiral::eRpL) {
+    fct_link.m_fct_name = "AsymmFactorRL_Af_2f";
+  } else {
+    throw std::invalid_argument("AfInfo: Need PrEW eLpR/eRpL chiral configs!");
+  }
+
+  return fct_link;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace SetupHelp
+} // namespace PrEWUtils

--- a/source/src/SetupHelp/ChiAsymmInfo.cpp
+++ b/source/src/SetupHelp/ChiAsymmInfo.cpp
@@ -1,0 +1,127 @@
+#include <Names/CoefNaming.h>
+#include <Names/FctNaming.h>
+#include <Names/ParNaming.h>
+#include <SetupHelp/ChiAsymmInfo.h>
+
+#include <string>
+
+#include "spdlog/spdlog.h"
+
+namespace PrEWUtils {
+namespace SetupHelp {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+ChiAsymmInfo::ChiAsymmInfo(const std::string &distr_name,
+                           const std::vector<std::string> &chiral_configs,
+                           const std::vector<std::string> &par_names)
+    : m_distr_name(distr_name), m_chiral_configs(chiral_configs),
+      m_par_names(par_names), m_n_asymms(m_chiral_configs.size() - 1) {
+  /** Constructor copying the given variables.
+      If no asymmetry parameter names are provided then the default asymmetry
+      parameter names are used.
+  **/
+
+  // Check that chiral configs were given
+  if (m_chiral_configs.size() == 0) {
+    throw std::invalid_argument("ChiAsymmInfo:"
+                                " Got empty vector for chiral configs!");
+  }
+
+  // Check if par_names are given and if their length is as expected.
+  // It either isn't true use the default naming.
+  if ((m_par_names == std::vector<std::string>()) ||
+      (m_par_names.size() != m_chiral_configs.size() - 1)) {
+    if (m_n_asymms == 1) {
+      // Only one asymmetry
+      m_par_names = {Names::ParNaming::asymm_par_name(m_distr_name)};
+    } else {
+      // Multiple asymmetries
+      for (size_t a = 1; a < m_chiral_configs.size(); a++) {
+        m_par_names.push_back(
+            Names::ParNaming::asymm_par_name(m_distr_name, a));
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// Access functions
+
+const std::string &ChiAsymmInfo::get_distr_name() const { return m_distr_name; }
+
+const std::vector<std::string> &ChiAsymmInfo::get_chiral_configs() const {
+  return m_chiral_configs;
+}
+
+const std::vector<std::string> &ChiAsymmInfo::get_par_names() const {
+  return m_par_names;
+}
+
+int ChiAsymmInfo::get_n_asymms() const { return m_n_asymms; }
+
+//------------------------------------------------------------------------------
+// Functions to use asymmetry in PrEW
+
+PrEW::Fit::ParVec ChiAsymmInfo::get_pars(double initial_val,
+                                         double initial_unc) const {
+  /** Get the FitPar's for this asymmetry.
+   **/
+  PrEW::Fit::ParVec pars{};
+  for (const auto &par_name : m_par_names) {
+    pars.push_back(PrEW::Fit::FitPar(par_name, initial_val, initial_unc));
+  }
+  return pars;
+}
+
+PrEW::Data::FctLink
+ChiAsymmInfo::get_fct_link(int energy, const std::string &chiral_config) const {
+  /** Get PrEW function link for a single chiral configuration.
+      These function links are used by PrEW as instructions for how to set up
+      the bin predictions.
+   **/
+
+  // Determine which function to use
+  // -> Depends on place of chiral cross section in asymmetry
+  int chiral_config_index = this->chiral_config_index(chiral_config);
+  std::string fct_name =
+      Names::FctNaming::chiral_asymm_name(chiral_config_index, m_n_asymms+1);
+
+  // Get the coefficients needed for the function (chiral cross sections)
+  std::vector<std::string> coef_names = this->xs_coef_names(energy);
+
+  // Return instructions on how to build funciton for this chiral cross section
+  return {fct_name, m_par_names, coef_names};
+}
+
+//------------------------------------------------------------------------------
+// Internal functions
+//------------------------------------------------------------------------------
+
+int ChiAsymmInfo::chiral_config_index(const std::string &chiral_config) const {
+  /** Find the index of the given chiral configuration wrt. this asymmetry.
+   **/
+  auto chiral_config_it = std::find(m_chiral_configs.begin(),
+                                    m_chiral_configs.end(), chiral_config);
+  int chiral_config_index =
+      std::distance(m_chiral_configs.begin(), chiral_config_it);
+  return chiral_config_index;
+}
+
+std::vector<std::string> ChiAsymmInfo::xs_coef_names(int energy) const {
+  /** Determine the names of the chiral cross section coefficients for this
+      asymmetry using the naming conventions.
+  **/
+  std::vector<std::string> coef_names{};
+  for (const auto &chiral_config : m_chiral_configs) {
+    coef_names.push_back(Names::CoefNaming::chi_xs_coef_name(
+        {m_distr_name, chiral_config, energy}));
+  }
+  return coef_names;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace SetupHelp
+} // namespace PrEWUtils

--- a/source/src/Setups/RKDistrSetup.cpp
+++ b/source/src/Setups/RKDistrSetup.cpp
@@ -766,17 +766,6 @@ std::vector<PrEW::Data::DistrInfo> RKDistrSetup::get_infos_chi(
 
 //------------------------------------------------------------------------------
 
-void RKDistrSetup::add_asymm_par( const std::string & par_name ) {
-  /** Add an asymmetry parameter to the list of common parameters.
-      By construction those are limited to [-1,1] are expected to be 0.
-      (They describe the deviation from the prediction.)
-  **/
-  PrEW::Fit::FitPar asymm_par { par_name, 0.0, 0.0001 };
-  m_common_pars.push_back(asymm_par);
-}
-
-//------------------------------------------------------------------------------
-
 void RKDistrSetup::add_chi_xs_sum_coefs(
   const std::string & distr_name,
   int energy,

--- a/source/src/Setups/RKDistrSetup.cpp
+++ b/source/src/Setups/RKDistrSetup.cpp
@@ -647,6 +647,27 @@ PrEW::Data::PredLink & RKDistrSetup::find_pred_link(
 
 //------------------------------------------------------------------------------
 
+PrEW::Data::PredDistr &
+RKDistrSetup::find_pred_distr(const PrEW::Data::DistrInfo & info){
+  /** Find PredDistr in the used distributions and return (non-const) reference 
+      to it.
+  **/
+  auto info_cond =
+    [info](const PrEW::Data::PredDistr &pred){return pred.m_info==info;};
+  auto pred_it = 
+    std::find_if(m_used_distrs.begin(), m_used_distrs.end(), info_cond);
+  
+  if ( pred_it == m_used_distrs.end() ) {
+    throw std::invalid_argument(("RKDistrSetup: Couldn't find PredDistr: " +
+                                info.m_distr_name + " " + info.m_pol_config + 
+                                " " + std::to_string(info.m_energy)).c_str());
+  }
+  
+  return *pred_it;
+}
+
+//------------------------------------------------------------------------------
+
 void RKDistrSetup::add_par(const PrEW::Fit::FitPar &par) {
   /** Add a parameter to the common parameters of this setup while first 
       checking that it does not already exist.


### PR DESCRIPTION
- Add namespace for conventions used in PrEW for function names, start with naming for chiral asymmetry functions.
- Change naming convention for cross section coefficient to include energy.
- Add helper class that can construct the PrEW parameters and instructions for a chiral asymmetry.
- Change the RKDistrSetup so that it uses the ChiAsymmInfo class instead of doing everything in its own functions.
- Remove 4-cross section asymmetry from RKDistrSetup (not very thought-through and not used).
- Remove deprecated asymmetry parameter function in RKDistrSetup.
- Add internal functions in RKDistrSetup for adding parameters and coefficients that check if the object already exists.
- Adapt RKDistrSetup functions to use internal parameter and coefficient adding functions.
- Add function to DataHelp that converts a given predicted distribution into a vector of doubles that can be used to build a coefficient.
- Add naming convention for coefficient describing a differential distribution.
- Add naming convention for coefficient describing a the index of the cos(Theta) observable in the observable vector.
- Add Af parameter naming convention.
- Add helper class for including an Af parameter for a 2-fermion distribution.
- Add internal distribution finder helper function to RKDistrSetup.
- Add functions to RKDistrSetup to add an Af parameter, provide the correct coefficients, and include it in the final setup.