### PR TITLE
Explicitely deprecate TGCs in setup (for now)

### DIFF
--- a/source/src/Setups/GeneralSetup.cpp
+++ b/source/src/Setups/GeneralSetup.cpp
@@ -145,10 +145,13 @@ void GeneralSetup::add(SetupHelp::ConstEffInfo info) {
   m_const_eff_infos.push_back(info);
 }
 
-void GeneralSetup::add(SetupHelp::TGCInfo info) {
+void GeneralSetup::add(SetupHelp::TGCInfo /*info*/) {
   /** Add an chiral cross section instruction.
    **/
-  m_TGC_infos.push_back(info);
+  // m_TGC_infos.push_back(info);
+  spdlog::error(
+    "TGC coefs currently deprecated (RK coefs found to be inaccurate)."
+    "Will proceed without TGCs." );
 }
 
 void GeneralSetup::add(SetupHelp::CrossSectionInfo info) {


### PR DESCRIPTION
- For now explicitely deprecate the activation of TGCs in the GeneralSetup, those coefficients had been found to be wrong.