### PR TITLE
General 2f parametrisation

### DIFF
--- a/source/include/SetupHelp/DifermionParamInfo.h
+++ b/source/include/SetupHelp/DifermionParamInfo.h
@@ -37,6 +37,11 @@ struct DifermionPars {
   // Index of cosine theta coordinate
   int _costheta_index{0};
 
+  // Potential parameter constraints
+  using ParConstr = std::pair<double, double>;
+  ParConstr s0_constr{}, Ae_constr{}, Af_constr{}, ef_constr{}, kL_constr{},
+      kR_constr{};
+
   // clang-format off
   // Optional arguments
   DifermionPars &s0(const std::string &name, double val = s0_def) {
@@ -61,6 +66,18 @@ struct DifermionPars {
 
   DifermionPars &costheta_index(int val) {_costheta_index = val; return *this;}
   
+  DifermionPars &constr_s0(double val, double unc) {
+    s0_constr = {val,unc}; return *this; }
+  DifermionPars &constr_Ae(double val, double unc) {
+    Ae_constr = {val,unc}; return *this; }
+  DifermionPars &constr_Af(double val, double unc) {
+    Af_constr = {val,unc}; return *this; }
+  DifermionPars &constr_ef(double val, double unc) {
+    ef_constr = {val,unc}; return *this; }
+  DifermionPars &constr_kL(double val, double unc) {
+    kL_constr = {val,unc}; return *this; }
+  DifermionPars &constr_kR(double val, double unc) {
+    kR_constr = {val,unc}; return *this; }
   // clang-format on
 };
 

--- a/source/include/SetupHelp/DifermionParamInfo.h
+++ b/source/include/SetupHelp/DifermionParamInfo.h
@@ -16,15 +16,67 @@
 namespace PrEWUtils {
 namespace SetupHelp {
 
+struct DifermionPars {
+  /** Helper struct to define the (potentially common) parameters of the 
+      2f distributions.
+      Essentially allows kinda Python-style optional arguments.
+      Inspired by:
+        https://softwareengineering.stackexchange.com/questions/329709/python-style-keyword-args-in-c-good-practice-or-bad-idea
+   **/
+  // Names of 2f parameters (for given distribution)
+  std::string s0_name {"default"};
+  std::string Ae_name {"default"};
+  std::string Af_name {"default"};
+  std::string ef_name {"default"};
+  std::string kL_name {"default"};
+  std::string kR_name {"default"};
+  
+  // Starting values of 2f parameters (for given distribution)
+  static constexpr double s0_def = 10000.;
+  static constexpr double Ae_def = 0;
+  static constexpr double Af_def = 0;
+  static constexpr double ef_def = 0;
+  static constexpr double kL_def = 0;
+  static constexpr double kR_def = 0;
+  double s0_val {s0_def};
+  double Ae_val {Ae_def};
+  double Af_val {Af_def};
+  double ef_val {ef_def};
+  double kL_val {kL_def};
+  double kR_val {kR_def};
+  
+  // Index of cosine theta coordinate
+  int _costheta_index {0};
+
+  // Optional arguments
+  DifermionPars& s0(const std::string &name, double val=s0_def) { s0_name = name; s0_val=val; return *this; }
+  DifermionPars& Ae(const std::string &name, double val=Ae_def) { Ae_name = name; Ae_val=val; return *this; }
+  DifermionPars& Af(const std::string &name, double val=Af_def) { Af_name = name; Af_val=val; return *this; }
+  DifermionPars& ef(const std::string &name, double val=ef_def) { ef_name = name; ef_val=val; return *this; }
+  DifermionPars& kL(const std::string &name, double val=kL_def) { kL_name = name; kL_val=val; return *this; }
+  DifermionPars& kR(const std::string &name, double val=kR_def) { kR_name = name; kR_val=val; return *this; }
+  
+  DifermionPars& s0(double val) { s0_val=val; return *this; }
+  DifermionPars& Ae(double val) { Ae_val=val; return *this; }
+  DifermionPars& Af(double val) { Af_val=val; return *this; }
+  DifermionPars& ef(double val) { ef_val=val; return *this; }
+  DifermionPars& kL(double val) { kL_val=val; return *this; }
+  DifermionPars& kR(double val) { kR_val=val; return *this; }
+  
+  DifermionPars& costheta_index(int val) { _costheta_index=val; return *this; }
+};
+
 class DifermionParamInfo {
   std::string m_distr_name{};
-  int m_costheta_index{};
+  DifermionPars m_par_info{};
+  
   PrEW::Fit::ParVec m_pars {};
   PrEW::Data::PredLinkVec m_pred_links{};
 
 public:
   // Constructors
-  DifermionParamInfo(const std::string &distr_name, int costheta_index = 0);
+  DifermionParamInfo(const std::string &distr_name,
+                     const DifermionPars &par_info = DifermionPars());
 
   // Access functions
   const PrEW::Fit::ParVec & get_pars() const;

--- a/source/include/SetupHelp/DifermionParamInfo.h
+++ b/source/include/SetupHelp/DifermionParamInfo.h
@@ -17,60 +17,61 @@ namespace PrEWUtils {
 namespace SetupHelp {
 
 struct DifermionPars {
-  /** Helper struct to define the (potentially common) parameters of the 
+  /** Helper struct to define the (potentially common) parameters of the
       2f distributions.
       Essentially allows kinda Python-style optional arguments.
       Inspired by:
         https://softwareengineering.stackexchange.com/questions/329709/python-style-keyword-args-in-c-good-practice-or-bad-idea
    **/
   // Names of 2f parameters (for given distribution)
-  std::string s0_name {"default"};
-  std::string Ae_name {"default"};
-  std::string Af_name {"default"};
-  std::string ef_name {"default"};
-  std::string kL_name {"default"};
-  std::string kR_name {"default"};
-  
-  // Starting values of 2f parameters (for given distribution)
-  static constexpr double s0_def = 1.0;
-  static constexpr double Ae_def = 0;
-  static constexpr double Af_def = 0;
-  static constexpr double ef_def = 0;
-  static constexpr double kL_def = 0;
-  static constexpr double kR_def = 0;
-  double s0_val {s0_def};
-  double Ae_val {Ae_def};
-  double Af_val {Af_def};
-  double ef_val {ef_def};
-  double kL_val {kL_def};
-  double kR_val {kR_def};
-  
-  // Index of cosine theta coordinate
-  int _costheta_index {0};
+  inline static const std::string def_name = "default";
+  std::string s0_name{def_name}, Ae_name{def_name}, Af_name{def_name},
+      ef_name{def_name}, kL_name{def_name}, kR_name{def_name};
 
+  // Starting values of 2f parameters (for given distribution)
+  static constexpr double s0_def{1.0}, Ae_def{0}, Af_def{0}, ef_def{0},
+      kL_def{0}, kR_def{0};
+  double s0_val{s0_def}, Ae_val{Ae_def}, Af_val{Af_def}, ef_val{ef_def},
+      kL_val{kL_def}, kR_val{kR_def};
+
+  // Index of cosine theta coordinate
+  int _costheta_index{0};
+
+  // clang-format off
   // Optional arguments
-  DifermionPars& s0(const std::string &name, double val=s0_def) { s0_name = name; s0_val=val; return *this; }
-  DifermionPars& Ae(const std::string &name, double val=Ae_def) { Ae_name = name; Ae_val=val; return *this; }
-  DifermionPars& Af(const std::string &name, double val=Af_def) { Af_name = name; Af_val=val; return *this; }
-  DifermionPars& ef(const std::string &name, double val=ef_def) { ef_name = name; ef_val=val; return *this; }
-  DifermionPars& kL(const std::string &name, double val=kL_def) { kL_name = name; kL_val=val; return *this; }
-  DifermionPars& kR(const std::string &name, double val=kR_def) { kR_name = name; kR_val=val; return *this; }
+  DifermionPars &s0(const std::string &name, double val = s0_def) {
+    s0_name = name; s0_val = val; return *this; }
+  DifermionPars &Ae(const std::string &name, double val = Ae_def) {
+    Ae_name = name; Ae_val = val; return *this; }
+  DifermionPars &Af(const std::string &name, double val = Af_def) {
+    Af_name = name; Af_val = val; return *this; }
+  DifermionPars &ef(const std::string &name, double val = ef_def) {
+    ef_name = name; ef_val = val; return *this; }
+  DifermionPars &kL(const std::string &name, double val = kL_def) {
+    kL_name = name; kL_val = val; return *this; }
+  DifermionPars &kR(const std::string &name, double val = kR_def) {
+    kR_name = name; kR_val = val; return *this; }
+
+  DifermionPars &s0(double val) { s0_val = val; return *this; }
+  DifermionPars &Ae(double val) { Ae_val = val; return *this; }
+  DifermionPars &Af(double val) { Af_val = val; return *this; }
+  DifermionPars &ef(double val) { ef_val = val; return *this; }
+  DifermionPars &kL(double val) { kL_val = val; return *this; }
+  DifermionPars &kR(double val) { kR_val = val; return *this; }
+
+  DifermionPars &costheta_index(int val) {_costheta_index = val; return *this;}
   
-  DifermionPars& s0(double val) { s0_val=val; return *this; }
-  DifermionPars& Ae(double val) { Ae_val=val; return *this; }
-  DifermionPars& Af(double val) { Af_val=val; return *this; }
-  DifermionPars& ef(double val) { ef_val=val; return *this; }
-  DifermionPars& kL(double val) { kL_val=val; return *this; }
-  DifermionPars& kR(double val) { kR_val=val; return *this; }
-  
-  DifermionPars& costheta_index(int val) { _costheta_index=val; return *this; }
+  // clang-format on
 };
 
 class DifermionParamInfo {
+  /** Class describing the information for difermion parametrisation using the
+      generalised differential cross section formula.
+   **/
   std::string m_distr_name{};
   DifermionPars m_par_info{};
-  
-  PrEW::Fit::ParVec m_pars {};
+
+  PrEW::Fit::ParVec m_pars{};
   PrEW::Data::PredLinkVec m_pred_links{};
 
 public:
@@ -79,7 +80,7 @@ public:
                      const DifermionPars &par_info = DifermionPars());
 
   // Access functions
-  const PrEW::Fit::ParVec & get_pars() const;
+  const PrEW::Fit::ParVec &get_pars() const;
 
   PrEW::Data::PredLinkVec
   get_pred_links(const PrEW::Data::InfoVec &infos) const;
@@ -88,7 +89,7 @@ public:
 
 protected:
   PrEW::Data::FctLink get_fct_link(const PrEW::Data::DistrInfo &info) const;
-  
+
   PrEW::Data::DistrInfo get_LR_info(int energy) const;
   PrEW::Data::DistrInfo get_RL_info(int energy) const;
 };

--- a/source/include/SetupHelp/DifermionParamInfo.h
+++ b/source/include/SetupHelp/DifermionParamInfo.h
@@ -32,7 +32,7 @@ struct DifermionPars {
   std::string kR_name {"default"};
   
   // Starting values of 2f parameters (for given distribution)
-  static constexpr double s0_def = 10000.;
+  static constexpr double s0_def = 1.0;
   static constexpr double Ae_def = 0;
   static constexpr double Af_def = 0;
   static constexpr double ef_def = 0;
@@ -88,6 +88,9 @@ public:
 
 protected:
   PrEW::Data::FctLink get_fct_link(const PrEW::Data::DistrInfo &info) const;
+  
+  PrEW::Data::DistrInfo get_LR_info(int energy) const;
+  PrEW::Data::DistrInfo get_RL_info(int energy) const;
 };
 
 using DifermionParamInfoVec = std::vector<DifermionParamInfo>;

--- a/source/include/SetupHelp/DifermionParamInfo.h
+++ b/source/include/SetupHelp/DifermionParamInfo.h
@@ -1,0 +1,46 @@
+#ifndef LIB_DIFERMIONPARAMINFO_H
+#define LIB_DIFERMIONPARAMINFO_H 1
+
+// Includes from PrEW
+#include <Data/CoefDistr.h>
+#include <Data/FctLink.h>
+#include <Data/PredDistr.h>
+#include <Data/PredLink.h>
+#include <Fit/FitPar.h>
+#include <GlobalVar/Chiral.h>
+
+// Standard library
+#include <string>
+#include <vector>
+
+namespace PrEWUtils {
+namespace SetupHelp {
+
+class DifermionParamInfo {
+  std::string m_distr_name{};
+  int m_costheta_index{};
+  PrEW::Fit::ParVec m_pars {};
+  PrEW::Data::PredLinkVec m_pred_links{};
+
+public:
+  // Constructors
+  DifermionParamInfo(const std::string &distr_name, int costheta_index = 0);
+
+  // Access functions
+  const PrEW::Fit::ParVec & get_pars() const;
+
+  PrEW::Data::PredLinkVec
+  get_pred_links(const PrEW::Data::InfoVec &infos) const;
+  PrEW::Data::CoefDistrVec
+  get_coefs(const PrEW::Data::PredDistrVec &preds) const;
+
+protected:
+  PrEW::Data::FctLink get_fct_link(const PrEW::Data::DistrInfo &info) const;
+};
+
+using DifermionParamInfoVec = std::vector<DifermionParamInfo>;
+
+} // namespace SetupHelp
+} // namespace PrEWUtils
+
+#endif

--- a/source/include/SetupHelp/ParOrder.h
+++ b/source/include/SetupHelp/ParOrder.h
@@ -27,14 +27,12 @@ static const IDMap default_par_map{
     {"Efficiencies", {"ConstEff"}},                                     //
     {"TGCs", {"Delta-g1Z", "Delta-kappa_gamma", "Delta-lambda_gamma"}}, //
     {"Asymmetries", {"DeltaA"}},                                        //
-    {"Ae", {"Ae_", "Ae"}},                                                    //
-    {"Af", {"Af_", "Af"}},                                                    //
-    {"2fPars", {"s0_", "ef_", "kL_", "kR_"}},
+    {"2fPars", {"s0_", "Ae_", "Af_", "ef_", "kL_", "kR_"}},             //
     {"XSectionScalings", {"ScaleTotChiXS"}}                             //
 };
 
 static const Ordering default_ordering{
-    "TGCs", "Asymmetries",  "Ae",      "Af", "2fPars", "Pols", "XSectionScalings",
+    "TGCs", "Asymmetries", "2fPars", "Pols", "XSectionScalings",
     "Lumi", "Efficiencies", "AccBoxes"};
 
 bool par_fits_ID(const PrEW::Fit::FitPar &par, const IDVec &ids);

--- a/source/include/SetupHelp/ParOrder.h
+++ b/source/include/SetupHelp/ParOrder.h
@@ -27,13 +27,14 @@ static const IDMap default_par_map{
     {"Efficiencies", {"ConstEff"}},                                     //
     {"TGCs", {"Delta-g1Z", "Delta-kappa_gamma", "Delta-lambda_gamma"}}, //
     {"Asymmetries", {"DeltaA"}},                                        //
-    {"Ae", {"Ae_"}},                                                    //
-    {"Af", {"Af_"}},                                                    //
+    {"Ae", {"Ae_", "Ae"}},                                                    //
+    {"Af", {"Af_", "Af"}},                                                    //
+    {"2fPars", {"Sigma0", "AR", "kL", "kR"}},
     {"XSectionScalings", {"ScaleTotChiXS"}}                             //
 };
 
 static const Ordering default_ordering{
-    "TGCs", "Asymmetries",  "Ae",      "Af", "Pols", "XSectionScalings",
+    "TGCs", "Asymmetries",  "Ae",      "Af", "2fPars", "Pols", "XSectionScalings",
     "Lumi", "Efficiencies", "AccBoxes"};
 
 bool par_fits_ID(const PrEW::Fit::FitPar &par, const IDVec &ids);

--- a/source/include/SetupHelp/ParOrder.h
+++ b/source/include/SetupHelp/ParOrder.h
@@ -20,20 +20,23 @@ using CategorizedPars = std::map<std::string, PrEW::Fit::ParVec>;
 
 // Map from "common name" to identifiers
 static const IDMap default_par_map{
-    {"Lumi", {"Lumi"}},                                                 //
-    {"Pols", {"ePol", "pPol"}},                                         //
-    {"AccBoxes", {"Acceptance_center", "Acceptance_width",              //
-                  "_dCenter", "_dWidth"}},                              //
-    {"Efficiencies", {"ConstEff"}},                                     //
-    {"TGCs", {"Delta-g1Z", "Delta-kappa_gamma", "Delta-lambda_gamma"}}, //
-    {"Asymmetries", {"DeltaA"}},                                        //
-    {"2fPars", {"s0_", "Ae_", "Af_", "ef_", "kL_", "kR_"}},             //
-    {"XSectionScalings", {"ScaleTotChiXS"}}                             //
-};
+    {"Lumi", {"Lumi"}},
+    {"Pols", {"ePol", "pPol"}},
+    {"AccBoxes",
+     {"Acceptance_center", "Acceptance_width", "_dCenter", "_dWidth"}},
+    {"Efficiencies", {"ConstEff"}},
+    {"TGCs", {"Delta-g1Z", "Delta-kappa_gamma", "Delta-lambda_gamma"}},
+    {"Asymmetries", {"DeltaA"}},
+    {"2f_scale", {"s0_"}},
+    {"2f_shape", {"Ae_", "Af_", "ef_", "kL_", "kR_"}},
+    {"XSectionScalings", {"ScaleTotChiXS"}}};
 
 static const Ordering default_ordering{
-    "TGCs", "Asymmetries", "2fPars", "Pols", "XSectionScalings",
-    "Lumi", "Efficiencies", "AccBoxes"};
+  "Lumi", "Pols", // Machine
+  "TGCs", "Asymmetries", "2f_shape", // Shape effects
+  "2f_scale", "XSectionScalings", // Scale effect
+  "Efficiencies", "AccBoxes" // Other systematics
+};
 
 bool par_fits_ID(const PrEW::Fit::FitPar &par, const IDVec &ids);
 

--- a/source/include/SetupHelp/ParOrder.h
+++ b/source/include/SetupHelp/ParOrder.h
@@ -29,7 +29,7 @@ static const IDMap default_par_map{
     {"Asymmetries", {"DeltaA"}},                                        //
     {"Ae", {"Ae_", "Ae"}},                                                    //
     {"Af", {"Af_", "Af"}},                                                    //
-    {"2fPars", {"Sigma0", "AR", "kL", "kR"}},
+    {"2fPars", {"s0_", "ef_", "kL_", "kR_"}},
     {"XSectionScalings", {"ScaleTotChiXS"}}                             //
 };
 

--- a/source/include/SetupHelp/SetupInfos.h
+++ b/source/include/SetupHelp/SetupInfos.h
@@ -1,0 +1,13 @@
+#ifndef LIB_PREWUTILS_SETUPINFOS_H
+#define LIB_PREWUTILS_SETUPINFOS_H 1
+
+#include<SetupHelp/AccBoxInfo.h>
+#include<SetupHelp/AccBoxPolynomialInfo.h>
+#include<SetupHelp/AfInfo.h>
+#include<SetupHelp/ConstEffInfo.h>
+#include<SetupHelp/CrossSectionInfo.h>
+#include<SetupHelp/DifermionParamInfo.h>
+#include<SetupHelp/RunInfo.h>
+#include<SetupHelp/TGCInfo.h>
+
+#endif

--- a/source/include/Setups/FitModifier.h
+++ b/source/include/Setups/FitModifier.h
@@ -2,6 +2,7 @@
 #define LIB_FITMODIFIER_H 1
 
 #include <SetupHelp/AfInfo.h>
+#include <SetupHelp/DifermionParamInfo.h>
 #include <SetupHelp/ParOrder.h>
 
 // includes from PrEW
@@ -24,6 +25,7 @@ class FitModifier {
 
   // Optional modification specifiers
   SetupHelp::AfInfoVec m_Af_infos{};
+  SetupHelp::DifermionParamInfoVec m_difermion_param_infos{};
 
   // Output specifiers
   SetupHelp::ParOrder::Ordering m_par_ordering{
@@ -39,6 +41,7 @@ public:
 
   // Instructions on what to modify
   void add(SetupHelp::AfInfo info);
+  void add(SetupHelp::DifermionParamInfo info);
 
   void set_par_ordering(const SetupHelp::ParOrder::Ordering &ordering,
                         const SetupHelp::ParOrder::IDMap &id_map =
@@ -51,6 +54,8 @@ public:
 protected:
   // Internal functions
   void apply_Af_mod(PrEW::Connect::DataConnector *connector,
+                    PrEW::Fit::ParVec *pars) const;
+  void apply_2f_mod(PrEW::Connect::DataConnector *connector,
                     PrEW::Fit::ParVec *pars) const;
 
   void add_to_connector(PrEW::Connect::DataConnector *connector,

--- a/source/include/Setups/GeneralSetup.h
+++ b/source/include/Setups/GeneralSetup.h
@@ -41,7 +41,6 @@ class GeneralSetup {
   SetupHelp::AccBoxPolynomialInfoVec m_acc_box_polyn_infos{};
   SetupHelp::ConstEffInfoVec m_const_eff_infos{};
   SetupHelp::CrossSectionInfoVec m_xsection_infos{};
-  SetupHelp::DifermionParamInfoVec m_2fparam_infos{};
   SetupHelp::TGCInfoVec m_TGC_infos{};
 
   // Output specifiers
@@ -69,7 +68,6 @@ public:
   void add(SetupHelp::AccBoxPolynomialInfo info);
   void add(SetupHelp::ConstEffInfo info);
   void add(SetupHelp::CrossSectionInfo info);
-  void add(SetupHelp::DifermionParamInfo info);
   void add(SetupHelp::TGCInfo info);
   // void add(SetupHelp::ConstEffInfo info);
 
@@ -102,7 +100,6 @@ protected:
   void complete_acc_box_setup(const PrEW::Data::InfoVec &infos);
   void complete_acc_box_polyn_setup(const PrEW::Data::InfoVec &infos);
   void complete_const_eff_setup(const PrEW::Data::InfoVec &infos);
-  void complete_2fparam_setup(const PrEW::Data::InfoVec &infos);
   void complete_TGC_setup(const PrEW::Data::InfoVec &infos);
   void complete_xsection_setup(const PrEW::Data::InfoVec &infos);
 

--- a/source/include/Setups/GeneralSetup.h
+++ b/source/include/Setups/GeneralSetup.h
@@ -41,6 +41,7 @@ class GeneralSetup {
   SetupHelp::AccBoxPolynomialInfoVec m_acc_box_polyn_infos{};
   SetupHelp::ConstEffInfoVec m_const_eff_infos{};
   SetupHelp::CrossSectionInfoVec m_xsection_infos{};
+  SetupHelp::DifermionParamInfoVec m_2fparam_infos{};
   SetupHelp::TGCInfoVec m_TGC_infos{};
 
   // Output specifiers
@@ -68,6 +69,7 @@ public:
   void add(SetupHelp::AccBoxPolynomialInfo info);
   void add(SetupHelp::ConstEffInfo info);
   void add(SetupHelp::CrossSectionInfo info);
+  void add(SetupHelp::DifermionParamInfo info);
   void add(SetupHelp::TGCInfo info);
   // void add(SetupHelp::ConstEffInfo info);
 
@@ -100,6 +102,7 @@ protected:
   void complete_acc_box_setup(const PrEW::Data::InfoVec &infos);
   void complete_acc_box_polyn_setup(const PrEW::Data::InfoVec &infos);
   void complete_const_eff_setup(const PrEW::Data::InfoVec &infos);
+  void complete_2fparam_setup(const PrEW::Data::InfoVec &infos);
   void complete_TGC_setup(const PrEW::Data::InfoVec &infos);
   void complete_xsection_setup(const PrEW::Data::InfoVec &infos);
 

--- a/source/include/Setups/GeneralSetup.h
+++ b/source/include/Setups/GeneralSetup.h
@@ -1,13 +1,8 @@
 #ifndef LIB_GENERALSETUP_H
 #define LIB_GENERALSETUP_H 1
 
-#include <SetupHelp/AccBoxInfo.h>
-#include <SetupHelp/AccBoxPolynomialInfo.h>
-#include <SetupHelp/ConstEffInfo.h>
-#include <SetupHelp/CrossSectionInfo.h>
+#include <SetupHelp/SetupInfos.h>
 #include <SetupHelp/ParOrder.h>
-#include <SetupHelp/RunInfo.h>
-#include <SetupHelp/TGCInfo.h>
 
 // Includes from PrEW
 #include "Connect/DataConnector.h"

--- a/source/src/SetupHelp/DifermionParamInfo.cpp
+++ b/source/src/SetupHelp/DifermionParamInfo.cpp
@@ -1,0 +1,143 @@
+#include <DataHelp/PredDistrHelp.h>
+#include <Names/CoefNaming.h>
+#include <Names/FctNaming.h>
+#include <Names/ParNaming.h>
+#include <SetupHelp/DifermionParamInfo.h>
+
+// inputs from PrEW
+#include <Data/DistrUtils.h>
+
+// Standard library
+#include <string>
+
+#include "spdlog/spdlog.h"
+
+namespace PrEWUtils {
+namespace SetupHelp {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+DifermionParamInfo::DifermionParamInfo(const std::string &distr_name,
+               int costheta_index)
+    : m_distr_name(distr_name), m_costheta_index(costheta_index) {
+      
+      
+   m_pars = {
+     PrEW::Fit::FitPar("Sigma0", 2500., 1.),
+     PrEW::Fit::FitPar("Ae", 0.21, 0.0001),
+     PrEW::Fit::FitPar("Af", 0.20, 0.0001),
+     PrEW::Fit::FitPar("AR", 0.25, 0.0001),
+     PrEW::Fit::FitPar("kL", 0.02, 0.0001),
+     PrEW::Fit::FitPar("kR", 0.02, 0.0001)
+   };
+   
+  // m_pars[0].fix();
+  // m_pars[1].fix();
+  // m_pars[2].fix();
+  // m_pars[3].fix();
+  // m_pars[4].fix();
+  // m_pars[5].fix();
+
+  // Create the prediction link (energy to be filled later)
+  PrEW::Data::DistrInfo info_LR{distr_name, PrEW::GlobalVar::Chiral::eLpR, 0};
+  PrEW::Data::DistrInfo info_RL{distr_name, PrEW::GlobalVar::Chiral::eRpL, 0};
+
+  auto fct_link_LR = this->get_fct_link(info_LR);
+  auto fct_link_RL = this->get_fct_link(info_RL);
+
+  m_pred_links.push_back(PrEW::Data::PredLink{info_LR, {fct_link_LR}, {}});
+  m_pred_links.push_back(PrEW::Data::PredLink{info_RL, {fct_link_RL}, {}});
+}
+
+//------------------------------------------------------------------------------
+// Access functions
+
+const PrEW::Fit::ParVec & DifermionParamInfo::get_pars() const { return m_pars; }
+
+PrEW::Data::PredLinkVec
+DifermionParamInfo::get_pred_links(const PrEW::Data::InfoVec &infos) const {
+  /** Get the linking instructions for PrEW.
+   **/
+  spdlog::debug("DifermionParamInfo: Getting prediction links.");
+  PrEW::Data::PredLinkVec pred_links = m_pred_links;
+
+  // Set the correct energy
+  int energy = infos.at(0).m_energy;
+  for (auto &pred_link : pred_links) {
+    pred_link.m_info.m_energy = energy;
+  }
+
+  return pred_links;
+}
+
+PrEW::Data::CoefDistrVec
+DifermionParamInfo::get_coefs(const PrEW::Data::PredDistrVec &preds) const {
+  /** Get all the coefficients needed for the function related to the chiral
+      cross sections.
+   **/
+  spdlog::debug("DifermionParamInfo: Getting coefficients.");
+  int energy = preds.at(0).get_info().m_energy;
+  PrEW::Data::DistrInfo info_LR{m_distr_name, PrEW::GlobalVar::Chiral::eLpR,
+                                energy};
+  PrEW::Data::DistrInfo info_RL{m_distr_name, PrEW::GlobalVar::Chiral::eRpL,
+                                energy};
+
+  PrEW::Data::CoefDistrVec coefs{}; // output vector
+
+  // Find the relevant distributions
+  auto pred_LR = PrEW::Data::DistrUtils::subvec_info(preds, info_LR).at(0);
+  auto pred_RL = PrEW::Data::DistrUtils::subvec_info(preds, info_RL).at(0);
+
+  // Find the distribution sums and differential values
+  auto LR_diff = DataHelp::PredDistrHelp::pred_to_coef(pred_LR, "signal");
+  auto RL_diff = DataHelp::PredDistrHelp::pred_to_coef(pred_RL, "signal");
+
+  // Differential distribution only need for itself
+  coefs.push_back(PrEW::Data::CoefDistr(
+      Names::CoefNaming::chi_distr_coef_name(info_LR), info_LR, LR_diff));
+  coefs.push_back(PrEW::Data::CoefDistr(
+      Names::CoefNaming::chi_distr_coef_name(info_RL), info_RL, RL_diff));
+
+  // Add index coefficients
+  coefs.push_back(
+      PrEW::Data::CoefDistr(Names::CoefNaming::costheta_index_coef_name(),
+                            info_LR, m_costheta_index));
+  coefs.push_back(
+      PrEW::Data::CoefDistr(Names::CoefNaming::costheta_index_coef_name(),
+                            info_RL, m_costheta_index));
+
+  return coefs;
+}
+
+//------------------------------------------------------------------------------
+// Internal functions
+//------------------------------------------------------------------------------
+
+PrEW::Data::FctLink
+DifermionParamInfo::get_fct_link(const PrEW::Data::DistrInfo &info) const {
+  /** Get PrEW function link for a single chiral configuration.
+      Chiral config must use PrEW conventions or naming chiral configs.
+      These function links are used by PrEW as instructions for how to set
+      up the bin predictions.
+   **/
+  PrEW::Data::FctLink fct_link{};
+  for (const auto & par: m_pars) {fct_link.m_pars.push_back(par.get_name());}
+  fct_link.m_coefs = {Names::CoefNaming::chi_distr_coef_name(info, "signal"),
+                      Names::CoefNaming::costheta_index_coef_name()};
+
+  if (info.m_pol_config == PrEW::GlobalVar::Chiral::eLpR) {
+    fct_link.m_fct_name = "General2fParam_LR";
+  } else if (info.m_pol_config == PrEW::GlobalVar::Chiral::eRpL) {
+    fct_link.m_fct_name = "General2fParam_RL";
+  } else {
+    throw std::invalid_argument("DifermionParamInfo: Need PrEW eLpR/eRpL chiral configs!");
+  }
+
+  return fct_link;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace SetupHelp
+} // namespace PrEWUtils

--- a/source/src/SetupHelp/DifermionParamInfo.cpp
+++ b/source/src/SetupHelp/DifermionParamInfo.cpp
@@ -39,6 +39,21 @@ DifermionParamInfo::DifermionParamInfo(const std::string &distr_name,
   auto kL = FitPar(p_name("kL", m_par_info.kL_name), m_par_info.kL_val, 0.001);
   auto kR = FitPar(p_name("kR", m_par_info.kR_name), m_par_info.kR_val, 0.001);
 
+  // clang-format off
+  if (m_par_info.s0_constr != DifermionPars::ParConstr()) { 
+    auto c = m_par_info.s0_constr; s0.set_constrgauss(c.first, c.second); }
+  if (m_par_info.Ae_constr != DifermionPars::ParConstr()) { 
+    auto c = m_par_info.Ae_constr; Ae.set_constrgauss(c.first, c.second); }
+  if (m_par_info.Af_constr != DifermionPars::ParConstr()) { 
+    auto c = m_par_info.Af_constr; Af.set_constrgauss(c.first, c.second); }
+  if (m_par_info.ef_constr != DifermionPars::ParConstr()) { 
+    auto c = m_par_info.ef_constr; ef.set_constrgauss(c.first, c.second); }
+  if (m_par_info.kL_constr != DifermionPars::ParConstr()) { 
+    auto c = m_par_info.kL_constr; kL.set_constrgauss(c.first, c.second); }
+  if (m_par_info.kR_constr != DifermionPars::ParConstr()) { 
+    auto c = m_par_info.kR_constr; kR.set_constrgauss(c.first, c.second); }
+  // clang-format on
+
   m_pars = {s0, Ae, Af, ef, kL, kR};
 
   // Create the prediction link (correct energy to be filled later)

--- a/source/src/SetupHelp/DifermionParamInfo.cpp
+++ b/source/src/SetupHelp/DifermionParamInfo.cpp
@@ -23,21 +23,23 @@ DifermionParamInfo::DifermionParamInfo(const std::string &distr_name,
     : m_distr_name(distr_name), m_par_info(par_info) {
 
   // Helper function to deal with default values of parameter names
-  auto par_name = [distr_name](const std::string &par,
-                               const std::string &name) {
-    if (name == "default") {
+  auto p_name = [distr_name](const std::string &par, const std::string &name) {
+    if (name == DifermionPars::def_name) {
       return par + "_" + distr_name;
     } else {
       return name;
     }
   };
 
-  m_pars = {{par_name("s0", m_par_info.s0_name), m_par_info.s0_val, 0.001},
-            {par_name("Ae", m_par_info.Ae_name), m_par_info.Ae_val, 0.001},
-            {par_name("Af", m_par_info.Af_name), m_par_info.Af_val, 0.001},
-            {par_name("ef", m_par_info.ef_name), m_par_info.ef_val, 0.001},
-            {par_name("kL", m_par_info.kL_name), m_par_info.kL_val, 0.001},
-            {par_name("kR", m_par_info.kR_name), m_par_info.kR_val, 0.001}};
+  using FitPar = PrEW::Fit::FitPar;
+  auto s0 = FitPar(p_name("s0", m_par_info.s0_name), m_par_info.s0_val, 0.001);
+  auto Ae = FitPar(p_name("Ae", m_par_info.Ae_name), m_par_info.Ae_val, 0.001);
+  auto Af = FitPar(p_name("Af", m_par_info.Af_name), m_par_info.Af_val, 0.001);
+  auto ef = FitPar(p_name("ef", m_par_info.ef_name), m_par_info.ef_val, 0.001);
+  auto kL = FitPar(p_name("kL", m_par_info.kL_name), m_par_info.kL_val, 0.001);
+  auto kR = FitPar(p_name("kR", m_par_info.kR_name), m_par_info.kR_val, 0.001);
+
+  m_pars = {s0, Ae, Af, ef, kL, kR};
 
   // Create the prediction link (correct energy to be filled later)
   PrEW::Data::DistrInfo info_LR = this->get_LR_info(0);

--- a/source/src/Setups/GeneralSetup.cpp
+++ b/source/src/Setups/GeneralSetup.cpp
@@ -145,6 +145,12 @@ void GeneralSetup::add(SetupHelp::ConstEffInfo info) {
   m_const_eff_infos.push_back(info);
 }
 
+void GeneralSetup::add(SetupHelp::DifermionParamInfo info) {
+  /** Add an difermion general parametrisation instruction.
+   **/
+  m_2fparam_infos.push_back(info);
+}
+
 void GeneralSetup::add(SetupHelp::TGCInfo /*info*/) {
   /** Add an chiral cross section instruction.
    **/
@@ -186,6 +192,7 @@ void GeneralSetup::complete_setup() {
   this->complete_acc_box_setup(infos);
   this->complete_acc_box_polyn_setup(infos);
   this->complete_const_eff_setup(infos);
+  this->complete_2fparam_setup(infos);
   this->complete_TGC_setup(infos);
   this->complete_xsection_setup(infos);
 
@@ -351,6 +358,16 @@ void GeneralSetup::complete_const_eff_setup(const PrEW::Data::InfoVec &infos) {
   for (const auto &const_eff : m_const_eff_infos) {
     this->add_pars(const_eff.get_pars());
     this->add_pred_links(const_eff.get_pred_links(infos));
+  }
+}
+
+void GeneralSetup::complete_2fparam_setup(const PrEW::Data::InfoVec &infos) {
+  /** Complete the part of the setup related to difermion parametrisations.
+   **/
+  for (const auto &param_2f : m_2fparam_infos) {
+    this->add_pars(param_2f.get_pars());
+    this->add_pred_links(param_2f.get_pred_links(infos));
+    this->add_coefs(param_2f.get_coefs(m_used_distrs));
   }
 }
 

--- a/source/src/Setups/GeneralSetup.cpp
+++ b/source/src/Setups/GeneralSetup.cpp
@@ -145,12 +145,6 @@ void GeneralSetup::add(SetupHelp::ConstEffInfo info) {
   m_const_eff_infos.push_back(info);
 }
 
-void GeneralSetup::add(SetupHelp::DifermionParamInfo info) {
-  /** Add an difermion general parametrisation instruction.
-   **/
-  m_2fparam_infos.push_back(info);
-}
-
 void GeneralSetup::add(SetupHelp::TGCInfo /*info*/) {
   /** Add an chiral cross section instruction.
    **/
@@ -192,7 +186,6 @@ void GeneralSetup::complete_setup() {
   this->complete_acc_box_setup(infos);
   this->complete_acc_box_polyn_setup(infos);
   this->complete_const_eff_setup(infos);
-  this->complete_2fparam_setup(infos);
   this->complete_TGC_setup(infos);
   this->complete_xsection_setup(infos);
 
@@ -358,16 +351,6 @@ void GeneralSetup::complete_const_eff_setup(const PrEW::Data::InfoVec &infos) {
   for (const auto &const_eff : m_const_eff_infos) {
     this->add_pars(const_eff.get_pars());
     this->add_pred_links(const_eff.get_pred_links(infos));
-  }
-}
-
-void GeneralSetup::complete_2fparam_setup(const PrEW::Data::InfoVec &infos) {
-  /** Complete the part of the setup related to difermion parametrisations.
-   **/
-  for (const auto &param_2f : m_2fparam_infos) {
-    this->add_pars(param_2f.get_pars());
-    this->add_pred_links(param_2f.get_pred_links(infos));
-    this->add_coefs(param_2f.get_coefs(m_used_distrs));
   }
 }
 


### PR DESCRIPTION
- First rough implementation of general 2f parametrisation.
- Create struct that allows Python style default parameters for the 2f parametrisation info.
- Create a combined SetupInfos header that summarizes the headers of the different info classes (they are all included anyways).
- Include the new difermion parametrisation in the general setup.
- Correct the names of the 2f parameters in the default parameter ordering.
- Remove the old 2f parameters from the parameter ordering or regroup them.
- Adjust to the switch to a relative total cross section parameter in the general 2f parametrisation.
- Improve the parameter ordering (mainly to get nicer correlation matrices).
- Remove 2f param again from the general setup to avoid confusion, it is only supposed to be in the FitModifier.
- Clean up the DifermionPars struct a bit.
- Allow setting constraints on the 2f parameters.